### PR TITLE
Fix static deploy try_files so multi-page sites resolve directory indexes (#11)

### DIFF
--- a/pts/tests/test_routing.pct.py
+++ b/pts/tests/test_routing.pct.py
@@ -105,7 +105,9 @@ def test_generate_subdomain_static():
     assert "docs.example.com" in config
     assert "file_server" in config
     assert "/srv/appgarden/apps/docs/source" in config
-    assert "try_files" in config
+    # Directory-index fallback so multi-page sites resolve /foo/ -> /foo/index.html
+    # before the SPA /index.html fallback (issue #11).
+    assert "try_files {path} {path}/index.html /index.html" in config
 
 # %% [markdown]
 # ## generate_caddy_config — subdirectory
@@ -150,6 +152,8 @@ def test_generate_subdirectory_static():
     assert "handle_path /docs/*" in config
     assert "file_server" in config
     assert "/srv/appgarden/apps/docs/source" in config
+    # Directory-index fallback for multi-page static sites (issue #11).
+    assert "try_files {path} {path}/index.html /index.html" in config
 
 # %% [markdown]
 # ## deploy_caddy_config

--- a/src/appgarden/templates/Caddyfile.static.j2
+++ b/src/appgarden/templates/Caddyfile.static.j2
@@ -1,5 +1,5 @@
 {{ domain }} {
     root * {{ source_path }}
     file_server
-    try_files {path} /index.html
+    try_files {path} {path}/index.html /index.html
 }

--- a/src/appgarden/templates/Caddyfile.subdirectory.j2
+++ b/src/appgarden/templates/Caddyfile.subdirectory.j2
@@ -5,7 +5,7 @@
 {% if app.method == "static" %}
         root * {{ app.source_path }}
         file_server
-        try_files {path} /index.html
+        try_files {path} {path}/index.html /index.html
 {% else %}
         reverse_proxy localhost:{{ app.port }} {
             header_up X-Forwarded-Prefix "/{{ app.path }}"

--- a/src/tests/test_routing.py
+++ b/src/tests/test_routing.py
@@ -74,7 +74,9 @@ def test_generate_subdomain_static():
     assert "docs.example.com" in config
     assert "file_server" in config
     assert "/srv/appgarden/apps/docs/source" in config
-    assert "try_files" in config
+    # Directory-index fallback so multi-page sites resolve /foo/ -> /foo/index.html
+    # before the SPA /index.html fallback (issue #11).
+    assert "try_files {path} {path}/index.html /index.html" in config
 
 # %% pts/tests/test_routing.pct.py 14
 def test_generate_subdirectory_single():
@@ -113,6 +115,8 @@ def test_generate_subdirectory_static():
     assert "handle_path /docs/*" in config
     assert "file_server" in config
     assert "/srv/appgarden/apps/docs/source" in config
+    # Directory-index fallback for multi-page static sites (issue #11).
+    assert "try_files {path} {path}/index.html /index.html" in config
 
 # %% pts/tests/test_routing.pct.py 18
 def test_deploy_caddy_config_subdomain():


### PR DESCRIPTION
Fixes #11.

## Problem

The `static` deploy method generated a Caddy site block with an SPA-style fallback:

```
try_files {path} /index.html
```

For a **multi-page** static site (e.g. a mirrored site with `/adu/index.html`, `/books/index.html`, …), a request for `/foo/` doesn't match a servable file, so it falls through to the root `/index.html` — **every subdirectory URL silently serves the homepage with HTTP 200**, even though the files on disk are correct.

## Fix

Try the directory index before the SPA fallback:

```
try_files {path} {path}/index.html /index.html
```

This serves `/foo/` → `/foo/index.html` when present, still serves real files, and keeps the `/index.html` SPA fallback for genuinely-missing paths — a safe default for both SPA and multi-page sites.

Applied to both static Caddy templates:
- `src/appgarden/templates/Caddyfile.static.j2` (subdomain static)
- `src/appgarden/templates/Caddyfile.subdirectory.j2` (the `static` branch inside `handle_path`)

These Jinja templates are the documented non-autogenerated exception, edited directly under `src/`.

## Tests

Strengthened `test_generate_subdomain_static` and `test_generate_subdirectory_static` in the nblite source (`pts/tests/test_routing.pct.py`) to assert the generated config contains `try_files {path} {path}/index.html /index.html`, then regenerated `src/` via `nbl export --reverse && nbl export`.

`uv run pytest src/tests/ -q` → **332 passed**.

## Notes

- Code fix only — no servers touched / nothing deployed.
- Kept independent of the separate ports/app_root PR (#10); branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)